### PR TITLE
fixed file name with extra world on content disposition

### DIFF
--- a/XDM_NEON/src/xdman/util/NetUtils.java
+++ b/XDM_NEON/src/xdman/util/NetUtils.java
@@ -97,14 +97,15 @@ public class NetUtils {
 		try {
 			if (header == null)
 				return null;
-			header = header.toLowerCase();
-			if (header.startsWith("attachment") || header.startsWith("inline")) {
+			//header = header.toLowerCase();
+			if (header.toLowerCase().startsWith("attachment") || header.toLowerCase().startsWith("inline")) {
 				String arr[] = header.split(";");
 				for (int i = 0; i < arr.length; i++) {
 					String str = arr[i].trim();
 					if (str.toLowerCase().startsWith("filename")) {
 						int index = str.indexOf('=');
-						return str.substring(index + 1).replace("\"", "").trim();
+						String encode=str.substring(index + 1).replace("\"", "").trim();
+						return XDMUtils.decodeFileName(encode);
 					}
 				}
 			}


### PR DESCRIPTION
When getting filename from content header, filename changed to Lower
case. And it is also required to do URL decode.
Fixed these file name issues.