### PR TITLE
Fix decoding of non-ASCII filenames and security issue

### DIFF
--- a/app/src/main/java/xdman/util/XDMUtils.java
+++ b/app/src/main/java/xdman/util/XDMUtils.java
@@ -14,6 +14,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -50,23 +52,16 @@ public class XDMUtils {
 	private static final char[] invalid_chars = { '/', '\\', '"', '?', '*', '<',
 			'>', ':', '|' };
 
-	public static String decodeFileName(String str) {
+	public static String decodeFileName(String encoded) {
+		String str = URLDecoder.decode(encoded, StandardCharsets.UTF_8);
 		char ch[] = str.toCharArray();
 		StringBuffer buf = new StringBuffer();
-		for (int i = 0; i < ch.length; i++) {
-			if (ch[i] == '/' || ch[i] == '\\' || ch[i] == '"' || ch[i] == '?'
-					|| ch[i] == '*' || ch[i] == '<' || ch[i] == '>'
-					|| ch[i] == ':')
+		for (char c : str.toCharArray()) {
+			if (c == '/' || c == '\\' || c == '"' || c == '?'
+					|| c == '*' || c == '<' || c == '>'
+					|| c == ':')
 				continue;
-			if (ch[i] == '%') {
-				if (i + 2 < ch.length) {
-					int c = Integer.parseInt(ch[i + 1] + "" + ch[i + 2], 16);
-					buf.append((char) c);
-					i += 2;
-					continue;
-				}
-			}
-			buf.append(ch[i]);
+			buf.append(c);
 		}
 		return buf.toString();
 	}

--- a/app/src/main/java/xdman/util/XDMUtils.java
+++ b/app/src/main/java/xdman/util/XDMUtils.java
@@ -15,7 +15,6 @@ import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -53,17 +52,34 @@ public class XDMUtils {
 			'>', ':', '|' };
 
 	public static String decodeFileName(String encoded) {
-		String str = URLDecoder.decode(encoded.replace("+", "%2B"), StandardCharsets.UTF_8);
-		char ch[] = str.toCharArray();
-		StringBuffer buf = new StringBuffer();
+		String str;
+		try {
+			str = URLDecoder.decode(encoded.replace("+", "%2B"), "UTF-8");
+		} catch (Exception e) {
+			StringBuilder builder = new StringBuilder();
+			char[] ch = encoded.toCharArray();
+			for (int i = 0; i < ch.length; i++) {
+				if (ch[i] == '%') {
+					if (i + 2 < ch.length) {
+						int c = Integer.parseInt(ch[i + 1] + "" + ch[i + 2], 16);
+						builder.append((char) c);
+						i += 2;
+						continue;
+					}
+				}
+				builder.append(ch[i]);
+			}
+			str = builder.toString();
+		}
+		StringBuilder builder = new StringBuilder();
 		for (char c : str.toCharArray()) {
 			if (c == '/' || c == '\\' || c == '"' || c == '?'
 					|| c == '*' || c == '<' || c == '>'
 					|| c == ':')
 				continue;
-			buf.append(c);
+			builder.append(c);
 		}
-		return buf.toString();
+		return builder.toString();
 	}
 
 	public static String getFileName(String uri) {

--- a/app/src/main/java/xdman/util/XDMUtils.java
+++ b/app/src/main/java/xdman/util/XDMUtils.java
@@ -53,7 +53,7 @@ public class XDMUtils {
 			'>', ':', '|' };
 
 	public static String decodeFileName(String encoded) {
-		String str = URLDecoder.decode(encoded, StandardCharsets.UTF_8);
+		String str = URLDecoder.decode(encoded.replace("+", "%2B"), StandardCharsets.UTF_8);
 		char ch[] = str.toCharArray();
 		StringBuffer buf = new StringBuffer();
 		for (char c : str.toCharArray()) {


### PR DESCRIPTION
Fixes #76
Fixes #110
Fixes #143
Fixes #232
Fixes #308
Fixes #358
Fixes #387
Fixes #430
Fixes #448

The old URL percent-encoding decoder did not support inputs like %C3%AA (which becomes ê) because it assumed all characters to only consist of one percent-sequence. This pull request uses the built-in Java URLDecoder to decode the string and thus fixes that issue.

There was also another problem where the decoded character was not checked, for example %2F becomes / which is not disallowed and might lead to security issues if downloaded from a specially-crafted server.
It now decodes the percents and then checks for illegal characters.

It is worth to note that the Java URLDecoder decodes "+" to " ", so the code encodes the "+" to "%2B" which are then decoded to +.

NOTE: I have tested the decoding code but not in XDM itself, please test it before merging.