### PR TITLE
Fixed weird file name issues

### DIFF
--- a/app/extensions/xdm-browser-monitor/firefox/bg.js
+++ b/app/extensions/xdm-browser-monitor/firefox/bg.js
@@ -44,7 +44,7 @@
         log("sending to xdm: " + response.url);
         var data = "url=" + response.url + "\r\n";
         if (file) {
-            data += "file=" + file + "\r\n";
+            data += "file=" + file.replaceAll(/[\\/:*?"<>\|\%]/g, "_") + "\r\n";
         }
         for (var i = 0; i < request.requestHeaders.length; i++) {
             data += "req=" + request.requestHeaders[i].name + ":" + request.requestHeaders[i].value + "\r\n";


### PR DESCRIPTION
# Summary
There was a problem with strange file names generated when saving files.
So I've added code to convert invalid strings to "_" on the Firefox extension side. It's like GetInvalidFileNameChars on DotNet.
I am not sure if this is enough, if this is the best way. I have not tested it with Chrome extensions.

## Examples of weird names

- Can We Beat Roblox SQUID GAME SEASON 2!? (NEW GAMES!) - YouTube
https://www.youtube.com/watch?v=MJrVmXjVg4w
"Can We Beat Roblox SQUID GAME SEASON 2!"
↓ fixed
"Can We Beat Roblox SQUID GAME SEASON 2!_ (NEW GAMES!) - YouTube"

-  Fate/Stay Night Official Trailer - YouTube
https://www.youtube.com/watch?v=aFyxNcwl3U0
"Stay Night Official Trailer - YouTube"
↓ fixed
"Fate_Stay Night Official Trailer - YouTube"

-  ［MV］ Apink(에이핑크) _ %%(Eung Eung(응응)) - YouTube
https://www.youtube.com/watch?v=499YUeNoYVE
"FILE"
↓ fixed
"[MV] Apink(에이핑크) _ __(Eung Eung(응응)) - YouTube"

Vertical bar "|" seems to have already been addressed in the java code.
I don't know about the new DotNet version.