### PR TITLE
Added showing multiple recent folders when choosing download location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ app/.classpath
 app/.project
 app/.settings/*
 app/target/*
+.idea
+app/xdman.iml

--- a/app/src/main/java/xdman/ui/components/XDMFileSelectionPanel.java
+++ b/app/src/main/java/xdman/ui/components/XDMFileSelectionPanel.java
@@ -92,9 +92,10 @@ public class XDMFileSelectionPanel extends JPanel implements ActionListener {
 
 		add(hbox, BorderLayout.EAST);
 		pop = new JPopupMenu();
-		if (!StringUtils.isNullOrEmptyOrBlank(Config.getInstance().getLastFolder())) {
-			pop.add(createMenuItem(Config.getInstance().getLastFolder()));
-		}
+		for (String recentFolder : Config.getInstance().getRecentFolders())
+        {
+            pop.add(createMenuItem(recentFolder));
+        }
 		pop.add(createMenuItem(Config.getInstance().getDownloadFolder()));
 		if (!Config.getInstance().isForceSingleFolder()) {
 			pop.add(createMenuItem(Config.getInstance().getCategoryDocuments()));


### PR DESCRIPTION
Instead of showing only the last folder in the drop-down menu of choosing the location for download

![image](https://user-images.githubusercontent.com/60978780/166133003-63c8cca3-b8c1-49a8-905e-f688f951b2bb.png)

XDM now supports multiple (5 currently but can be changed to any number) recent folder

![image](https://user-images.githubusercontent.com/60978780/165748750-e5079201-5108-41f3-8e03-ce38f118adaa.png)