### PR TITLE
Fixed(#812) not grabbing downloads from AMD driver site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ app/.classpath
 app/.project
 app/.settings/*
 app/target/*
+.idea
+app/xdman.iml 

--- a/app/src/main/java/xdman/XDMApp.java
+++ b/app/src/main/java/xdman/XDMApp.java
@@ -585,6 +585,7 @@ public class XDMApp implements DownloadListener, DownloadWindowListener, Compara
 				if (metadata.getType() == XDMConstants.FTP) {
 					d = new FtpDownloader(id, ent.getTempFolder(), metadata);
 				} else {
+					HttpDownloader.injectReferrerHeaders(metadata);
 					d = new HttpDownloader(id, ent.getTempFolder(), metadata);
 				}
 			}

--- a/app/src/main/java/xdman/downloaders/http/HttpDownloader.java
+++ b/app/src/main/java/xdman/downloaders/http/HttpDownloader.java
@@ -119,4 +119,27 @@ public class HttpDownloader extends SegmentDownloader {
 		return this.metadata;
 	}
 
+	public static void injectReferrerHeaders(HttpMetadata metadata)
+	{
+		String referrer = getReferrer(metadata.getUrl());
+
+		if (StringUtils.isNullOrEmpty(referrer))
+			return;
+
+		var headers = metadata.getHeaders();
+		headers.setValue("referer", referrer);
+		headers.setValue("origin", referrer);
+		metadata.setHeaders(headers);
+
+	}
+
+	// should contain different referrers of different sites
+	private static String getReferrer(String url)
+	{
+		if (url.contains("amd"))
+			return "https://www.amd.com/";
+
+		return null;
+	}
+
 }


### PR DESCRIPTION
Fixes [#812 ](https://github.com/subhra74/xdm/issues/812)

# Problem
Sites like **Amd driver site** prevent the download if it wasn't issued from the browser by checking the _referrer_ header
![image](https://user-images.githubusercontent.com/60978780/166437769-f786d5ca-bbc8-437b-a504-42cd12912a61.png)
 # Solution
Before starting the `Httpdownloader` headers for _referrer_ and _origin_ are injected into the _metadata_.
the fix was made in a way to allow different referrers to be added easily in the function `getReferrer`
